### PR TITLE
re-enabled background sync

### DIFF
--- a/Sailfish/ownNotes/python/ownnotes.py
+++ b/Sailfish/ownNotes/python/ownnotes.py
@@ -207,13 +207,11 @@ def saveNote(filepath, data, colorized=True):
     with open(filepath, 'w', encoding='utf-8') as fh:
         fh.write(_content)
 
-    # Note pushing removed to avoid the app locking up
-    # Perhaps this should be run in a different thread
-    #try:
-    #    relpath = os.path.join(category, _getValidFilename(_title.strip()) + '.txt')
-    #    sync.push_note(relpath)
-    #except Exception as err:
-    #    logger.Logger().logger.error(str(err))
+    try:
+        relpath = os.path.join(category, _getValidFilename(_title.strip()) + '.txt')
+        sync.launch_push_note(relpath)
+    except Exception as err:
+        logger.Logger().logger.error(str(err))
 
     return filepath
 

--- a/Sailfish/ownNotes/python/sync.py
+++ b/Sailfish/ownNotes/python/sync.py
@@ -358,7 +358,7 @@ class Sync(object):
             return True
 
     def launch_push_note(self, path):
-        self.thread = threading.Thread(target=self._wpushNote, args=[path, ])
+        self.thread = threading.Thread(target=self.push_note, args=[path, ])
         self.thread.start()
         return True
 


### PR DESCRIPTION
Hi David,

first of all - thanks a lot for re-animating ownNotes for Sailfish - it helps me a lot!

Today I saw that you had commented out "sync on save", looked into sync.py and found that threaded sync already was implemented - just mis-configured and not called.
So I fixed the setup of launch_note_push and changed owncloud.py to call launch_note_push instead of note_push.

Regards,

Marco
